### PR TITLE
Fix string literals inside params

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ coverage/
 tests/
 test-data/
 .*
+update-test-data.sh

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jsx-i18n",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Provides gettext-enhanced React components, a babel plugin for extracting the strings and a script to compile translated strings to a format usable by the components.",
   "main": "client/index.js",
   "scripts": {

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -36,9 +36,15 @@ const getTranslatableString = children => {
     } else if (child.type !== Param) {
       throw new Error(`Translate child components must be of type Param; got ${child.type.name}`);
     } else {
-      const {name: paramName, children: paramContent, value: paramValue} = child.props;
+      const {name: paramName, value: paramValue} = child.props;
+      let paramContent = child.props.children;
       if (usedParams.has(paramName)) {
         throw new Error(`Translate params must be unique; found ${paramName} more than once`);
+      } else if (Array.isArray(paramContent)) {
+        paramContent = paramContent
+          .join('')
+          .replace(/\s+/g, ' ')
+          .trim();
       } else if (paramContent !== undefined && typeof paramContent !== 'string') {
         throw new Error(`Unexpected Param child type: ${typeof paramContent}`);
       } else if (paramContent === undefined && paramValue === undefined) {

--- a/test-data/de_DE.json
+++ b/test-data/de_DE.json
@@ -158,7 +158,7 @@
     "<HTML> is unescaped when extracted": [
       "<HTML> wird unescaped extracted"
     ],
-    "xxx foo bar{test}{x} y{/x} moo": [
+    "xxx foo bar{test}{x}y{/x} moo": [
       [
         "Fragment",
         null,
@@ -174,7 +174,7 @@
           {
             "name": "x"
           },
-          " y"
+          "y"
         ],
         " muh"
       ]
@@ -209,6 +209,20 @@
             "name": "tag"
           },
           "hallo"
+        ]
+      ]
+    ],
+    "This param is using string literals: {emphasize}hello world{/emphasize}": [
+      [
+        "Fragment",
+        null,
+        "Dieser Parameter verwendet String Literals: ",
+        [
+          "Param",
+          {
+            "name": "emphasize"
+          },
+          "Hallo Welt"
         ]
       ]
     ],

--- a/test-data/de_DE.po
+++ b/test-data/de_DE.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Test\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-06-19 10:48+0200\n"
+"POT-Creation-Date: 2019-06-19 12:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de_DE\n"
@@ -50,7 +50,7 @@ msgstr "Foo: {foo}"
 msgid "mixed: {mixedCase}"
 msgstr "gemischt: {mixedCase}"
 
-#: test-data/example.jsx:86 test-data/example.jsx:126
+#: test-data/example.jsx:86 test-data/example.jsx:129
 msgid "You have {count} rat."
 msgid_plural "You have {count} rats."
 msgstr[0] "Du hast {count} Ratte."
@@ -81,26 +81,32 @@ msgid "<HTML> is unescaped when extracted"
 msgstr "<HTML> wird unescaped extracted"
 
 #: test-data/example.jsx:119
-msgid "xxx foo bar{test}{x} y{/x} moo"
-msgstr "xxx foo bar{test}{x} y{/x} muh"
+msgid "xxx foo bar{test}{x}y{/x} moo"
+msgstr "xxx foo bar{test}{x}y{/x} muh"
 
-#: test-data/example.jsx:136
+#: test-data/example.jsx:139
 msgid "Little cats:"
 msgstr "Junge Katzen:"
 
-#: test-data/example.jsx:138
+#: test-data/example.jsx:141
 msgid "Little dogs:"
 msgstr "Junge Hunde:"
 
-#: test-data/example.jsx:140
+#: test-data/example.jsx:143
 msgid "This is an emphasized dynamic value: {number}"
 msgstr "Das ist ein hervorgehobener dynamischer Wert: {number}"
 
-#: test-data/example.jsx:144
+#: test-data/example.jsx:147
 msgid "This is an emphasized translated value: {tag}hello{/tag}"
 msgstr "Das ist ein hervorgehobener übersetzter Wert: {tag}hallo{/tag}"
 
-#: test-data/example.jsx:41 test-data/example.jsx:136
+#: test-data/example.jsx:153
+msgid "This param is using string literals: {emphasize}hello world{/emphasize}"
+msgstr ""
+"Dieser Parameter verwendet String Literals: {emphasize}Hallo "
+"Welt{/emphasize}"
+
+#: test-data/example.jsx:41 test-data/example.jsx:139
 msgctxt "cat"
 msgid "offspring"
 msgstr "Kätzchen"
@@ -124,7 +130,7 @@ msgctxt "params-test"
 msgid "foo: {foo}"
 msgstr "Foo: {foo}"
 
-#: test-data/example.jsx:138
+#: test-data/example.jsx:141
 msgctxt "dog"
 msgid "offspring"
 msgstr "Welpe"

--- a/test-data/example.jsx
+++ b/test-data/example.jsx
@@ -116,11 +116,13 @@ export const TestComponent = ({translate}) => {
       <br />
       <Translate>&lt;HTML&gt; is unescaped when extracted</Translate>
       <br />
-      {/* prettier-ignore */}
       <Translate>
         xxx foo bar
         <Param name="test" value={1} />
-        <Param name="x" value={'2'}> y</Param>{' '}
+        <Param name="x" value={'2'}>
+          {' '}
+          y
+        </Param>{' '}
         moo
       </Translate>
       <hr />
@@ -146,6 +148,12 @@ export const TestComponent = ({translate}) => {
         This is an emphasized translated value:{' '}
         <Param name="tag" wrapper={<em />}>
           hello
+        </Param>
+      </Translate>
+      <Translate>
+        This param is using string literals:{' '}
+        <Param name="emphasize" wrapper={<em />}>
+          {'hello' + ' ' + 'world'}
         </Param>
       </Translate>
     </div>

--- a/tests/__snapshots__/client.test.js.snap
+++ b/tests/__snapshots__/client.test.js.snap
@@ -65,6 +65,10 @@ exports[`Example component works properly with translations 1`] = `
   <em>
     hallo
   </em>
+  Dieser Parameter verwendet String Literals: 
+  <em>
+    Hallo Welt
+  </em>
 </div>
 `;
 
@@ -137,6 +141,11 @@ exports[`Example component works properly without translations 1`] = `
    
   <em>
     hello
+  </em>
+  This param is using string literals:
+   
+  <em>
+    hello world
   </em>
 </div>
 `;

--- a/tests/__snapshots__/extract.test.js.snap
+++ b/tests/__snapshots__/extract.test.js.snap
@@ -33,7 +33,7 @@ Object {
 exports[`Invalid stuff fails 3`] = `
 Object {
   "errors": Array [
-    "test-data/invalid/param-invalid-child.jsx: Unexpected Param child node: JSXExpressionContainer
+    "test-data/invalid/param-invalid-child.jsx: Expressions may only contain a string literal or a concatenation of them; found NumericLiteral instead
   1 | const ParamInvalidChild = () => (
   2 |     <Translate>
 > 3 |         <Param name=\\"foo\\">{1}</Param>
@@ -48,7 +48,7 @@ Object {
 exports[`Invalid stuff fails 4`] = `
 Object {
   "errors": Array [
-    "test-data/invalid/param-too-many-children.jsx: Param has too many children (3), expected max. 1
+    "test-data/invalid/param-too-many-children.jsx: Unexpected Param child tag: span
   3 |         <Param name=\\"foo\\">
   4 |             a
 > 5 |             <span />
@@ -266,7 +266,7 @@ msgid \\"mixed: {mixedCase}\\"
 msgstr \\"\\"
 
 #: test-data/example.jsx:86
-#: test-data/example.jsx:127
+#: test-data/example.jsx:129
 msgid \\"You have {count} rat.\\"
 msgid_plural \\"You have {count} rats.\\"
 msgstr[0] \\"\\"
@@ -297,28 +297,32 @@ msgstr \\"\\"
 msgid \\"<HTML> is unescaped when extracted\\"
 msgstr \\"\\"
 
-#: test-data/example.jsx:120
-msgid \\"xxx foo bar{test}{x} y{/x} moo\\"
-msgstr \\"\\"
-
-#: test-data/example.jsx:137
-msgid \\"Little cats:\\"
+#: test-data/example.jsx:119
+msgid \\"xxx foo bar{test}{x}y{/x} moo\\"
 msgstr \\"\\"
 
 #: test-data/example.jsx:139
-msgid \\"Little dogs:\\"
+msgid \\"Little cats:\\"
 msgstr \\"\\"
 
 #: test-data/example.jsx:141
+msgid \\"Little dogs:\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx:143
 msgid \\"This is an emphasized dynamic value: {number}\\"
 msgstr \\"\\"
 
-#: test-data/example.jsx:145
+#: test-data/example.jsx:147
 msgid \\"This is an emphasized translated value: {tag}hello{/tag}\\"
 msgstr \\"\\"
 
+#: test-data/example.jsx:153
+msgid \\"This param is using string literals: {emphasize}hello world{/emphasize}\\"
+msgstr \\"\\"
+
 #: test-data/example.jsx:41
-#: test-data/example.jsx:137
+#: test-data/example.jsx:139
 msgctxt \\"cat\\"
 msgid \\"offspring\\"
 msgstr \\"\\"
@@ -342,7 +346,7 @@ msgctxt \\"params-test\\"
 msgid \\"foo: {foo}\\"
 msgstr \\"\\"
 
-#: test-data/example.jsx:139
+#: test-data/example.jsx:141
 msgctxt \\"dog\\"
 msgid \\"offspring\\"
 msgstr \\"\\"",
@@ -399,7 +403,7 @@ msgid \\"mixed: {mixedCase}\\"
 msgstr \\"\\"
 
 #: test-data/example.jsx:86
-#: test-data/example.jsx:127
+#: test-data/example.jsx:129
 msgid \\"You have {count} rat.\\"
 msgid_plural \\"You have {count} rats.\\"
 msgstr[0] \\"\\"
@@ -430,28 +434,32 @@ msgstr \\"\\"
 msgid \\"<HTML> is unescaped when extracted\\"
 msgstr \\"\\"
 
-#: test-data/example.jsx:120
-msgid \\"xxx foo bar{test}{x} y{/x} moo\\"
-msgstr \\"\\"
-
-#: test-data/example.jsx:137
-msgid \\"Little cats:\\"
+#: test-data/example.jsx:119
+msgid \\"xxx foo bar{test}{x}y{/x} moo\\"
 msgstr \\"\\"
 
 #: test-data/example.jsx:139
-msgid \\"Little dogs:\\"
+msgid \\"Little cats:\\"
 msgstr \\"\\"
 
 #: test-data/example.jsx:141
+msgid \\"Little dogs:\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx:143
 msgid \\"This is an emphasized dynamic value: {number}\\"
 msgstr \\"\\"
 
-#: test-data/example.jsx:145
+#: test-data/example.jsx:147
 msgid \\"This is an emphasized translated value: {tag}hello{/tag}\\"
 msgstr \\"\\"
 
+#: test-data/example.jsx:153
+msgid \\"This param is using string literals: {emphasize}hello world{/emphasize}\\"
+msgstr \\"\\"
+
 #: test-data/example.jsx:41
-#: test-data/example.jsx:137
+#: test-data/example.jsx:139
 msgctxt \\"cat\\"
 msgid \\"offspring\\"
 msgstr \\"\\"
@@ -475,7 +483,7 @@ msgctxt \\"params-test\\"
 msgid \\"foo: {foo}\\"
 msgstr \\"\\"
 
-#: test-data/example.jsx:139
+#: test-data/example.jsx:141
 msgctxt \\"dog\\"
 msgid \\"offspring\\"
 msgstr \\"\\"",

--- a/tests/__snapshots__/po2react.test.js.snap
+++ b/tests/__snapshots__/po2react.test.js.snap
@@ -152,6 +152,20 @@ Object {
         ],
       ],
     ],
+    "This param is using string literals: {emphasize}hello world{/emphasize}": Array [
+      Array [
+        "Fragment",
+        null,
+        "Dieser Parameter verwendet String Literals: ",
+        Array [
+          "Param",
+          Object {
+            "name": "emphasize",
+          },
+          "Hallo Welt",
+        ],
+      ],
+    ],
     "You    are ugly!": Array [
       "Du    bist hässlich!",
     ],
@@ -312,7 +326,7 @@ Object {
         ],
       ],
     ],
-    "xxx foo bar{test}{x} y{/x} moo": Array [
+    "xxx foo bar{test}{x}y{/x} moo": Array [
       Array [
         "Fragment",
         null,
@@ -328,7 +342,7 @@ Object {
           Object {
             "name": "x",
           },
-          " y",
+          "y",
         ],
         " muh",
       ],


### PR DESCRIPTION
Use the same logic we use inside `<Translate>`.

There was an edge case that is very unlikely to happen in any real application, but if a param's content did have leading/trailing whitespace, it is now properly stripped during extraction, so the pot file will change when extracting the strings again.
