### PR TITLE
Add prop as to Translate and TranslatePlural

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -209,7 +209,7 @@ export const makeComponents = (...args) => {
     static propTypes = {
       children: PropTypes.any.isRequired,
       context: PropTypes.string,
-      as: PropTypes.element,
+      as: PropTypes.elementType,
     };
 
     static defaultProps = {
@@ -233,19 +233,16 @@ export const makeComponents = (...args) => {
       const {children, context, as, ...rest} = this.props;
       const gettextFunc = pickGettextFunc(context, gettext, pgettext);
       const translation = gettextFunc(this.original);
-      if (translation === this.original) {
-        // if there's no translation gettext gives us the input string
-        // which does not contain the information needed to render it!
-        // unfortunately this means that we also cannot strip surrounding
-        // whitespace since we may have more than just text in the children,
-        // which is why we fail during extraction in that case
-        return children;
+      let content = children;
+      if (translation !== this.original) {
+        content = renderTranslation(translation, getParamValues(this));
       }
-      return React.createElement(
-        as || React.Fragment,
-        rest,
-        renderTranslation(translation, getParamValues(this))
-      );
+      // if there's no translation gettext gives us the input string
+      // which does not contain the information needed to render it!
+      // unfortunately this means that we also cannot strip surrounding
+      // whitespace since we may have more than just text in the children,
+      // which is why we fail during extraction in that case
+      return React.createElement(as, rest, content);
     }
   }
 
@@ -254,7 +251,7 @@ export const makeComponents = (...args) => {
       children: PropTypes.any.isRequired,
       count: PropTypes.number.isRequired,
       context: PropTypes.string,
-      as: PropTypes.element,
+      as: PropTypes.elementType,
     };
 
     static defaultProps = {

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -296,17 +296,16 @@ export const makeComponents = (...args) => {
       const {count, context, as, ...rest} = this.props;
       const gettextFunc = pickGettextFunc(context, ngettext, npgettext);
       const translation = gettextFunc(this.singularString, this.pluralString, count);
+      let content;
       if (translation === this.singularString) {
-        return this.getChild(false);
+        content = this.getChild(false);
       } else if (translation === this.pluralString) {
-        return this.getChild(true);
+        content = this.getChild(true);
+      } else {
+        const values = getParamValues(this.getChild(count !== 1));
+        content = renderTranslation(translation, values);
       }
-      const values = getParamValues(this.getChild(count !== 1));
-      return React.createElement(
-        as || React.Fragment,
-        rest,
-        renderTranslation(translation, values)
-      );
+      return React.createElement(as, rest, content);
     }
   }
 

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -209,10 +209,12 @@ export const makeComponents = (...args) => {
     static propTypes = {
       children: PropTypes.any.isRequired,
       context: PropTypes.string,
+      as: PropTypes.element,
     };
 
     static defaultProps = {
       context: undefined,
+      as: React.Fragment,
     };
 
     // eslint-disable-next-line no-shadow, react/sort-comp
@@ -228,7 +230,7 @@ export const makeComponents = (...args) => {
     }
 
     render() {
-      const {children, context} = this.props;
+      const {children, context, as, ...rest} = this.props;
       const gettextFunc = pickGettextFunc(context, gettext, pgettext);
       const translation = gettextFunc(this.original);
       if (translation === this.original) {
@@ -239,7 +241,11 @@ export const makeComponents = (...args) => {
         // which is why we fail during extraction in that case
         return children;
       }
-      return renderTranslation(translation, getParamValues(this));
+      return React.createElement(
+        as || React.Fragment,
+        rest,
+        renderTranslation(translation, getParamValues(this))
+      );
     }
   }
 
@@ -248,10 +254,12 @@ export const makeComponents = (...args) => {
       children: PropTypes.any.isRequired,
       count: PropTypes.number.isRequired,
       context: PropTypes.string,
+      as: PropTypes.element,
     };
 
     static defaultProps = {
       context: undefined,
+      as: React.Fragment,
     };
 
     // eslint-disable-next-line no-shadow
@@ -288,7 +296,7 @@ export const makeComponents = (...args) => {
     }
 
     render() {
-      const {count, context} = this.props;
+      const {count, context, as, ...rest} = this.props;
       const gettextFunc = pickGettextFunc(context, ngettext, npgettext);
       const translation = gettextFunc(this.singularString, this.pluralString, count);
       if (translation === this.singularString) {
@@ -297,7 +305,11 @@ export const makeComponents = (...args) => {
         return this.getChild(true);
       }
       const values = getParamValues(this.getChild(count !== 1));
-      return renderTranslation(translation, values);
+      return React.createElement(
+        as || React.Fragment,
+        rest,
+        renderTranslation(translation, values)
+      );
     }
   }
 

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -31,6 +31,20 @@ test('Basic translation works', () => {
       Fetchez la vache <Param name="number" value={5} />
     </Translate>
   ).toEqual(['translated-Fetchez la vache ', '5']);
+
+  expectJSX(<Translate as="p">kajak</Translate>).toEqual(
+    renderer.create(<p>translated-kajak</p>).toJSON()
+  );
+  expectJSX(
+    <Translate as="span" className="myclass">
+      Fetchez la vache <Param name="number" value={5} />
+    </Translate>
+  ).toEqual(
+    renderer
+      .create(<span className="myclass">{['translated-Fetchez la vache ', '5']}</span>)
+      .toJSON()
+  );
+
   expect(Translate.string('kajak')).toBe('translated-kajak');
   expect(Translate.string('hello {what}', {what: 'world'})).toBe('translated-hello world');
   expect(Translate.string('hello {whatElse}', {whatElse: 'planet'})).toBe(


### PR DESCRIPTION
Depends on #13 

Adds the possibility to render `Translate` as another component, to avoid increased nesting when translating a string.

```html
<Translate as="div" styleName="style">my text here</Translate>
```

```html
<div styleName="style">
  <Translate>
    my text here
  </Translate>
</div>
```

An example of a [similar lib that does the same](https://github.com/lingui/js-lingui/blob/main/packages/react/src/Trans.tsx#L102).