### PR TITLE
Add TypeScript types for better intellisense/autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.4.0",
   "description": "Provides gettext-enhanced React components, a babel plugin for extracting the strings and a script to compile translated strings to a format usable by the components.",
   "main": "client/index.js",
+  "types": "client/index.d.ts",
   "scripts": {
-    "build": "rm -rf client/ tools/ && babel src/ --out-dir ./ && chmod +x tools/cli.js",
+    "build": "rm -rf client/ tools/ && babel src/ --out-dir ./ && chmod +x tools/cli.js && cp src/client/index.d.ts client/index.d.ts",
     "prepare": "npm run build",
     "eslint": "eslint --ext .js --ext .jsx src/ tests/ test-data/",
     "update-test-data": "./update-test-data.sh",

--- a/src/client/index.d.ts
+++ b/src/client/index.d.ts
@@ -1,0 +1,85 @@
+import * as React from 'react';
+
+export interface ParamProps {
+  /** Parameter name */
+  name: string;
+
+  /** Value to render */
+  value?: any;
+
+  /** A React element to wrap the parameter value/children */
+  wrapper?: React.ReactElement;
+  children?: React.ReactNode;
+}
+
+export const Param: React.FC<ParamProps>;
+
+export interface SingularProps {
+  children: React.ReactNode;
+}
+
+export const Singular: React.FC<SingularProps>;
+
+export interface PluralProps {
+  children: React.ReactNode;
+}
+
+export const Plural: React.FC<PluralProps>;
+
+export interface TranslateProps {
+  /** Message context */
+  context?: string;
+
+  /** An element type to render as */
+  as?: React.ComponentType;
+  children: React.ReactNode;
+}
+
+export const Translate: React.FC<TranslateProps> & {
+  /**
+   * Translate a string
+   * @param string The message to translate
+   * @param args Optional context and parameters
+   * @returns The translated string
+   */
+  string: (string: string, ...args: any[]) => string;
+};
+
+export interface PluralTranslateProps {
+  /** Determines whether the singular or plural will be used */
+  count: number;
+
+  /** Message context */
+  context?: string;
+
+  /** An element type to render as */
+  as?: React.ComponentType;
+  children: React.ReactNode;
+}
+
+export const PluralTranslate: React.FC<PluralTranslateProps> & {
+  /**
+   * Translate a string including pluralization
+   * @param singular The singular form of the message
+   * @param plural The plural form of the message
+   * @param count Determines whether the singular or plural will be used
+   * @param args Optional context and parameters
+   * @returns The translated string
+   */
+  string: (singular: string, plural: string, count: number, ...args: any[]) => string;
+};
+
+export interface Config {
+  gettext: (msg: string) => string;
+  ngettext: (msg: string, msgpl: string, n: number) => string;
+  pgettext?: (ctx: string, msg: string) => string;
+  npgettext?: (ctx: string, msg: string, msgpl: string, n: number) => string;
+  options?: any;
+}
+
+export interface Components {
+  Translate: typeof Translate;
+  PluralTranslate: typeof PluralTranslate;
+}
+
+export function makeComponents(config: Config): Components;


### PR DESCRIPTION
Sources I used:
https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html
https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

See e.g. SUI for an example in the 'wild':
https://github.com/Semantic-Org/Semantic-UI-React

Examples:
![image](https://github.com/indico/react-jsx-i18n/assets/8739637/5ffaf64f-6ef7-4b84-9607-05b2664d703a)
![image](https://github.com/indico/react-jsx-i18n/assets/8739637/fa3ee860-7269-411d-86b3-02859f5e0e33)
