### PR TITLE
Use functional react components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jsx-i18n",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Provides gettext-enhanced React components, a babel plugin for extracting the strings and a script to compile translated strings to a format usable by the components.",
   "main": "client/index.js",
   "types": "client/index.d.ts",


### PR DESCRIPTION
This also fixes a case where `original` got stuck tot the old value in case of a Translate element being updated to a new set of children, and thus picking the wrong translation.