### PR TITLE
Add base dir arg for relative paths

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,14 +9,14 @@ on:
 jobs:
   tests:
     name: Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
-          node-version: 14.x
+          node-version: 18
 
       - name: Install dependencies
         run: npm install

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jsx-i18n",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Provides gettext-enhanced React components, a babel plugin for extracting the strings and a script to compile translated strings to a format usable by the components.",
   "main": "client/index.js",
   "types": "client/index.d.ts",

--- a/src/tools/cli.js
+++ b/src/tools/cli.js
@@ -45,10 +45,16 @@ yargs
         coerce: val => val.split(','),
         describe: 'file extensions to consider',
       });
+      y.option('base', {
+        alias: 'b',
+        default: null,
+        type: 'string',
+        describe: 'base dir to generate relative file paths; default to current dir',
+      });
     },
     argv => {
       const files = flattenPaths(argv.paths, argv.ext);
-      const {pot, errors} = extractFromFiles(files);
+      const {pot, errors} = extractFromFiles(files, argv.base || process.cwd());
       if (errors) {
         errors.forEach(err => console.error(err));
         process.exit(1);

--- a/src/tools/extract.js
+++ b/src/tools/extract.js
@@ -6,9 +6,9 @@ import moment from 'moment-timezone';
 import {mergeEntries} from 'babel-plugin-extract-text/src/builders';
 import makeI18nPlugin from './extract-plugin';
 
-const extractFromFiles = (files, headers = undefined, highlightErrors = true) => {
+const extractFromFiles = (files, base, headers = undefined, highlightErrors = true) => {
   const errors = [];
-  const {i18nPlugin, entries} = makeI18nPlugin();
+  const {i18nPlugin, entries} = makeI18nPlugin(base);
 
   files.forEach(file => {
     try {

--- a/tests/__snapshots__/extract.test.js.snap
+++ b/tests/__snapshots__/extract.test.js.snap
@@ -511,6 +511,147 @@ msgstr \\"\\"",
 }
 `;
 
+exports[`Messages are properly extracted 3`] = `
+Object {
+  "pot": "msgid \\"\\"
+msgstr \\"\\"
+\\"POT-Creation-Date: 2018-04-18 22:20+0000\\\\n\\"
+\\"Content-Type: text/plain; charset=utf-8\\\\n\\"
+\\"Content-Transfer-Encoding: 8bit\\\\n\\"
+\\"MIME-Version: 1.0\\\\n\\"
+\\"Generated-By: react-jsx-i18n-extract\\\\n\\"
+
+#: example.jsx:37
+#: example.jsx:38
+#: example.jsx:86
+msgid \\"\\\\\\"<strong>Rats.</strong>\\\\\\"\\"
+msgstr \\"\\"
+
+#: example.jsx:39
+#: example.jsx:40
+msgid \\"foobar\\"
+msgstr \\"\\"
+
+#: example.jsx:42
+msgid \\"You are ugly!\\"
+msgstr \\"\\"
+
+#: example.jsx:43
+msgid \\"space invader\\"
+msgstr \\"\\"
+
+#: example.jsx:44
+msgid \\"cat\\"
+msgid_plural \\"cats\\"
+msgstr[0] \\"\\"
+msgstr[1] \\"\\"
+
+#: example.jsx:47
+msgid \\"one {foo}\\"
+msgid_plural \\"many {foo}\\"
+msgstr[0] \\"\\"
+msgstr[1] \\"\\"
+
+#: example.jsx:50
+msgid \\"foo {weird} bar {hello}{test} xxx\\"
+msgstr \\"\\"
+
+#: example.jsx:55
+msgid \\"foo: {foo}\\"
+msgstr \\"\\"
+
+#: example.jsx:57
+msgid \\"mixed: {mixedCase}\\"
+msgstr \\"\\"
+
+#: example.jsx:88
+#: example.jsx:131
+msgid \\"You have {count} rat.\\"
+msgid_plural \\"You have {count} rats.\\"
+msgstr[0] \\"\\"
+msgstr[1] \\"\\"
+
+#: example.jsx:99
+msgid \\"Hello & World\\"
+msgstr \\"\\"
+
+#: example.jsx:101
+msgid \\"Hey {name}, you want to {link}click me{/link} and you know it!\\"
+msgstr \\"\\"
+
+#: example.jsx:109
+#: example.jsx:111
+msgid \\"Bye World\\"
+msgstr \\"\\"
+
+#: example.jsx:113
+msgid \\"Some <HTML> & entities: → &\\"
+msgstr \\"\\"
+
+#: example.jsx:116
+msgid \\"Hover me\\"
+msgstr \\"\\"
+
+#: example.jsx:119
+msgid \\"<HTML> is unescaped when extracted\\"
+msgstr \\"\\"
+
+#: example.jsx:121
+msgid \\"xxx foo bar{test}{x} y{/x} moo\\"
+msgstr \\"\\"
+
+#: example.jsx:141
+msgid \\"Little cats:\\"
+msgstr \\"\\"
+
+#: example.jsx:143
+msgid \\"Little dogs:\\"
+msgstr \\"\\"
+
+#: example.jsx:145
+msgid \\"This is an emphasized dynamic value: {number}\\"
+msgstr \\"\\"
+
+#: example.jsx:149
+msgid \\"This is an emphasized translated value: {tag}hello{/tag}\\"
+msgstr \\"\\"
+
+#: example.jsx:155
+msgid \\"This param is using string literals: {emphasize}hello world{/emphasize}\\"
+msgstr \\"\\"
+
+#: example.jsx:41
+#: example.jsx:141
+msgctxt \\"cat\\"
+msgid \\"offspring\\"
+msgstr \\"\\"
+
+#: example.jsx:45
+msgctxt \\"big\\"
+msgid \\"cat\\"
+msgid_plural \\"cats\\"
+msgstr[0] \\"\\"
+msgstr[1] \\"\\"
+
+#: example.jsx:49
+msgctxt \\"c\\"
+msgid \\"one {foo}\\"
+msgid_plural \\"many {foo}\\"
+msgstr[0] \\"\\"
+msgstr[1] \\"\\"
+
+#: example.jsx:56
+msgctxt \\"params-test\\"
+msgid \\"foo: {foo}\\"
+msgstr \\"\\"
+
+#: example.jsx:143
+msgctxt \\"dog\\"
+msgid \\"offspring\\"
+msgstr \\"\\"",
+}
+`;
+
 exports[`Non-string call ignored 1`] = `
 Object {
   "pot": "msgid \\"\\"

--- a/tests/extract.test.js
+++ b/tests/extract.test.js
@@ -1,10 +1,12 @@
 import extractFromFiles from '../src/tools/extract';
 
-const expectExtracted = (file, headers) => expect(extractFromFiles([file], headers, false));
+const expectExtracted = (file, headers, base) =>
+  expect(extractFromFiles([file], base || process.cwd(), headers, false));
 
 test('Messages are properly extracted', () => {
   expectExtracted('test-data/example.jsx', {Custom: 'Headers'}).toMatchSnapshot();
   expectExtracted('test-data/example.jsx').toMatchSnapshot();
+  expectExtracted('test-data/example.jsx', undefined, 'test-data').toMatchSnapshot();
 });
 
 test('Invalid stuff fails', () => {


### PR DESCRIPTION
Previously it always used the process cwd, but in some cases that's not ideal, and due to how node works you can't just chdir before executing the command.