### PR TITLE
Make source file reference verbosity configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jsx-i18n",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Provides gettext-enhanced React components, a babel plugin for extracting the strings and a script to compile translated strings to a format usable by the components.",
   "main": "client/index.js",
   "types": "client/index.d.ts",

--- a/src/tools/cli.js
+++ b/src/tools/cli.js
@@ -51,10 +51,20 @@ yargs
         type: 'string',
         describe: 'base dir to generate relative file paths; default to current dir',
       });
+      y.option('add-location', {
+        alias: 'L',
+        type: 'string',
+        choices: ['full', 'file', 'never'],
+        default: 'full',
+      });
     },
     argv => {
       const files = flattenPaths(argv.paths, argv.ext);
-      const {pot, errors} = extractFromFiles(files, argv.base || process.cwd());
+      const cfg = {
+        base: argv.base || process.cwd(),
+        addLocation: argv.addLocation,
+      };
+      const {pot, errors} = extractFromFiles(files, cfg);
       if (errors) {
         errors.forEach(err => console.error(err));
         process.exit(1);

--- a/src/tools/extract.js
+++ b/src/tools/extract.js
@@ -6,9 +6,9 @@ import moment from 'moment-timezone';
 import {mergeEntries} from 'babel-plugin-extract-text/src/builders';
 import makeI18nPlugin from './extract-plugin';
 
-const extractFromFiles = (files, base, headers = undefined, highlightErrors = true) => {
+const extractFromFiles = (files, cfg, headers = undefined, highlightErrors = true) => {
   const errors = [];
-  const {i18nPlugin, entries} = makeI18nPlugin(base);
+  const {i18nPlugin, entries} = makeI18nPlugin(cfg);
 
   files.forEach(file => {
     try {

--- a/tests/__snapshots__/extract.test.js.snap
+++ b/tests/__snapshots__/extract.test.js.snap
@@ -652,6 +652,249 @@ msgstr \\"\\"",
 }
 `;
 
+exports[`Messages are properly extracted 4`] = `
+Object {
+  "pot": "msgid \\"\\"
+msgstr \\"\\"
+\\"POT-Creation-Date: 2018-04-18 22:20+0000\\\\n\\"
+\\"Content-Type: text/plain; charset=utf-8\\\\n\\"
+\\"Content-Transfer-Encoding: 8bit\\\\n\\"
+\\"MIME-Version: 1.0\\\\n\\"
+\\"Generated-By: react-jsx-i18n-extract\\\\n\\"
+
+#: test-data/example.jsx
+msgid \\"\\\\\\"<strong>Rats.</strong>\\\\\\"\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx
+msgid \\"foobar\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx
+msgid \\"You are ugly!\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx
+msgid \\"space invader\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx
+msgid \\"cat\\"
+msgid_plural \\"cats\\"
+msgstr[0] \\"\\"
+msgstr[1] \\"\\"
+
+#: test-data/example.jsx
+msgid \\"one {foo}\\"
+msgid_plural \\"many {foo}\\"
+msgstr[0] \\"\\"
+msgstr[1] \\"\\"
+
+#: test-data/example.jsx
+msgid \\"foo {weird} bar {hello}{test} xxx\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx
+msgid \\"foo: {foo}\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx
+msgid \\"mixed: {mixedCase}\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx
+msgid \\"You have {count} rat.\\"
+msgid_plural \\"You have {count} rats.\\"
+msgstr[0] \\"\\"
+msgstr[1] \\"\\"
+
+#: test-data/example.jsx
+msgid \\"Hello & World\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx
+msgid \\"Hey {name}, you want to {link}click me{/link} and you know it!\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx
+msgid \\"Bye World\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx
+msgid \\"Some <HTML> & entities: → &\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx
+msgid \\"Hover me\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx
+msgid \\"<HTML> is unescaped when extracted\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx
+msgid \\"xxx foo bar{test}{x} y{/x} moo\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx
+msgid \\"Little cats:\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx
+msgid \\"Little dogs:\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx
+msgid \\"This is an emphasized dynamic value: {number}\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx
+msgid \\"This is an emphasized translated value: {tag}hello{/tag}\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx
+msgid \\"This param is using string literals: {emphasize}hello world{/emphasize}\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx
+msgctxt \\"cat\\"
+msgid \\"offspring\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx
+msgctxt \\"big\\"
+msgid \\"cat\\"
+msgid_plural \\"cats\\"
+msgstr[0] \\"\\"
+msgstr[1] \\"\\"
+
+#: test-data/example.jsx
+msgctxt \\"c\\"
+msgid \\"one {foo}\\"
+msgid_plural \\"many {foo}\\"
+msgstr[0] \\"\\"
+msgstr[1] \\"\\"
+
+#: test-data/example.jsx
+msgctxt \\"params-test\\"
+msgid \\"foo: {foo}\\"
+msgstr \\"\\"
+
+#: test-data/example.jsx
+msgctxt \\"dog\\"
+msgid \\"offspring\\"
+msgstr \\"\\"",
+}
+`;
+
+exports[`Messages are properly extracted 5`] = `
+Object {
+  "pot": "msgid \\"\\"
+msgstr \\"\\"
+\\"POT-Creation-Date: 2018-04-18 22:20+0000\\\\n\\"
+\\"Content-Type: text/plain; charset=utf-8\\\\n\\"
+\\"Content-Transfer-Encoding: 8bit\\\\n\\"
+\\"MIME-Version: 1.0\\\\n\\"
+\\"Generated-By: react-jsx-i18n-extract\\\\n\\"
+
+msgid \\"\\\\\\"<strong>Rats.</strong>\\\\\\"\\"
+msgstr \\"\\"
+
+msgid \\"foobar\\"
+msgstr \\"\\"
+
+msgid \\"You are ugly!\\"
+msgstr \\"\\"
+
+msgid \\"space invader\\"
+msgstr \\"\\"
+
+msgid \\"cat\\"
+msgid_plural \\"cats\\"
+msgstr[0] \\"\\"
+msgstr[1] \\"\\"
+
+msgid \\"one {foo}\\"
+msgid_plural \\"many {foo}\\"
+msgstr[0] \\"\\"
+msgstr[1] \\"\\"
+
+msgid \\"foo {weird} bar {hello}{test} xxx\\"
+msgstr \\"\\"
+
+msgid \\"foo: {foo}\\"
+msgstr \\"\\"
+
+msgid \\"mixed: {mixedCase}\\"
+msgstr \\"\\"
+
+msgid \\"You have {count} rat.\\"
+msgid_plural \\"You have {count} rats.\\"
+msgstr[0] \\"\\"
+msgstr[1] \\"\\"
+
+msgid \\"Hello & World\\"
+msgstr \\"\\"
+
+msgid \\"Hey {name}, you want to {link}click me{/link} and you know it!\\"
+msgstr \\"\\"
+
+msgid \\"Bye World\\"
+msgstr \\"\\"
+
+msgid \\"Some <HTML> & entities: → &\\"
+msgstr \\"\\"
+
+msgid \\"Hover me\\"
+msgstr \\"\\"
+
+msgid \\"<HTML> is unescaped when extracted\\"
+msgstr \\"\\"
+
+msgid \\"xxx foo bar{test}{x} y{/x} moo\\"
+msgstr \\"\\"
+
+msgid \\"Little cats:\\"
+msgstr \\"\\"
+
+msgid \\"Little dogs:\\"
+msgstr \\"\\"
+
+msgid \\"This is an emphasized dynamic value: {number}\\"
+msgstr \\"\\"
+
+msgid \\"This is an emphasized translated value: {tag}hello{/tag}\\"
+msgstr \\"\\"
+
+msgid \\"This param is using string literals: {emphasize}hello world{/emphasize}\\"
+msgstr \\"\\"
+
+msgctxt \\"cat\\"
+msgid \\"offspring\\"
+msgstr \\"\\"
+
+msgctxt \\"big\\"
+msgid \\"cat\\"
+msgid_plural \\"cats\\"
+msgstr[0] \\"\\"
+msgstr[1] \\"\\"
+
+msgctxt \\"c\\"
+msgid \\"one {foo}\\"
+msgid_plural \\"many {foo}\\"
+msgstr[0] \\"\\"
+msgstr[1] \\"\\"
+
+msgctxt \\"params-test\\"
+msgid \\"foo: {foo}\\"
+msgstr \\"\\"
+
+msgctxt \\"dog\\"
+msgid \\"offspring\\"
+msgstr \\"\\"",
+}
+`;
+
 exports[`Non-string call ignored 1`] = `
 Object {
   "pot": "msgid \\"\\"

--- a/tests/extract.test.js
+++ b/tests/extract.test.js
@@ -1,12 +1,14 @@
 import extractFromFiles from '../src/tools/extract';
 
-const expectExtracted = (file, headers, base) =>
-  expect(extractFromFiles([file], base || process.cwd(), headers, false));
+const expectExtracted = (file, headers, base, addLocation = 'full') =>
+  expect(extractFromFiles([file], {base: base || process.cwd(), addLocation}, headers, false));
 
 test('Messages are properly extracted', () => {
   expectExtracted('test-data/example.jsx', {Custom: 'Headers'}).toMatchSnapshot();
   expectExtracted('test-data/example.jsx').toMatchSnapshot();
   expectExtracted('test-data/example.jsx', undefined, 'test-data').toMatchSnapshot();
+  expectExtracted('test-data/example.jsx', undefined, undefined, 'file').toMatchSnapshot();
+  expectExtracted('test-data/example.jsx', undefined, undefined, 'never').toMatchSnapshot();
 });
 
 test('Invalid stuff fails', () => {


### PR DESCRIPTION
(Python's) Babel has the same option, so this allows being consistent when disabling line numbers for babel-based extractors.